### PR TITLE
Fix crash with empty string

### DIFF
--- a/jsbind.nim
+++ b/jsbind.nim
@@ -83,7 +83,9 @@ elif defined(emscripten):
             // resulting nim string.
             var l = lengthBytesUTF8(s);
             var b = _nimem_ps(l);
-            stringToUTF8(s, _nimem_sb(b), l + 1);
+            if (l != 0) {
+                stringToUTF8(s, _nimem_sb(b), l + 1);
+            }
             return b;
         };
 


### PR DESCRIPTION
Implementation for `_nimem_sb` tries to access an array at non-existing index in case of empty string. This causes the code to crash.