### PR TITLE
Make importing property with custom name possible

### DIFF
--- a/jsbind.nim
+++ b/jsbind.nim
@@ -340,6 +340,9 @@ elif defined(emscripten):
     macro jsimportProp*(p: untyped): typed =
         jsImportAux(p, true, p.unpackedName, true)
 
+    macro jsimportPropWithName*(name: string = "", p: untyped): typed =
+        jsImportAux(p, true, $name, true)
+
     proc setupUnhandledExceptionHandler*() =
         onUnhandledException = proc(msg: string) =
             discard EM_ASM_INT("throw new Error(UTF8ToString($0));", cstring(msg))

--- a/jsbind.nimble
+++ b/jsbind.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.1"
+version       = "0.1.1"
 author        = "Yuriy Glukhov"
 description   = "Bind to JavaScript and Emscripten environments"
 license       = "MIT"


### PR DESCRIPTION
This change allows for such useful code to exist: `proc typ*(self: Event): jsstring {.jsimportPropWithName: "type".}`