### PR TITLE
Upgrade to new Emscripten

### DIFF
--- a/jsbind.nim
+++ b/jsbind.nim
@@ -207,9 +207,9 @@ elif defined(emscripten):
         var dynCall = ""
         if isClosure:
             let argForwardsWithEnv = (@argForwardParts & "b").join(",")
-            dynCall = "Runtime.dynCall(b?'" & argsSig & "i':'" & argsSig & "',a,b?[" & argForwardsWithEnv & "]:[" & argForwards & "])"
+            dynCall = "dynCall(b?'" & argsSig & "i':'" & argsSig & "',a,b?[" & argForwardsWithEnv & "]:[" & argForwards & "])"
         else:
-            dynCall = "Runtime.dynCall('" & argsSig & "'," & jsParamName & ",[" & argForwards & "])"
+            dynCall = "dynCall('" & argsSig & "'," & jsParamName & ",[" & argForwards & "])"
 
         # if wrapDynCallInTryCatch:
         #     dynCall = "try{" & dynCall & "}catch(e){_nimem_e(e);}"


### PR DESCRIPTION
Running an application built with modern Emscripten results in an error without this fix: `TypeError: Runtime.dynCall is not a function.`